### PR TITLE
hotfix: deserializer panic while error occurs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = 'examples/app_state.rs'
 
 [package]
 name = 'obsidian'
-version = '0.2.1'
+version = '0.2.2'
 authors = [
     'Gan Jun Kai <kuhn96@gmail.com>',
     'Wai Pai Lee <pailee.wai@gmail.com>',

--- a/src/router/req_deserializer.rs
+++ b/src/router/req_deserializer.rs
@@ -423,18 +423,14 @@ impl de::Error for Error {
 
 impl Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str(&self.to_string())
-    }
-}
-
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
         match *self {
-            Error::Message(ref msg) => msg,
-            Error::NoneError => "Input should not be None",
+            Error::Message(ref msg) => formatter.write_str(msg),
+            Error::NoneError => formatter.write_str("Input should not be None"),
         }
     }
 }
+
+impl std::error::Error for Error {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Issue

Program panic if providing wrong query names in an endpoint that parses uri query.

## Correct Behaviour

Program return `Result` with `Error`.

## Reproduce

1. Make an endpoint which call `uri_query` method with struct data. 
2. Access the URL without query or with wrong query names.

## Causes

When error occurs, serde do not call deprecated Error::description anymore instead of fmt. When calling to_string for Error, it calls fmt too. This makes infinite loop occurs and stack overflow. This only occurs at running app, test case would not fail. I am not sure why.