### PR TITLE
feat: add new syntactic sugar for nested routes

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -255,10 +255,20 @@ ctx.build(Response::ok().html("<!DOCTYPE html><html><head><link rel=\"shotcut ic
         ctx.build(res).ok()
     });
 
-    let mut form_router = Router::new();
+    app.scope("admin", |router: &mut Router| {
+        router.get("test", |ctx: Context| async move {
+            ctx.build("Hello admin test").ok()
+        });
 
-    form_router.get("/formtest", |ctx: Context| async move {
-        ctx.build_file("./test.html").await.ok()
+        router.get("test2", |ctx: Context| async move {
+            ctx.build("Hello admin test 2").ok()
+        });
+    });
+
+    app.scope("form", |router: &mut Router| {
+        router.get("/formtest", |ctx: Context| async move {
+            ctx.build_file("/.test.html").await.ok()
+        });
     });
 
     // form_router.post("/formtest", |mut ctx: Context| async move{
@@ -268,8 +278,6 @@ ctx.build(Response::ok().html("<!DOCTYPE html><html><head><link rel=\"shotcut ic
 
     //     Ok(response::json(param_test, StatusCode::OK))
     // });
-
-    let mut param_router = Router::new();
 
     // param_router.get("/paramtest/:id", |ctx: Context| async move {
     //     let param_test: i32 = ctx.param("id")?;
@@ -291,21 +299,21 @@ ctx.build(Response::ok().html("<!DOCTYPE html><html><head><link rel=\"shotcut ic
     let logger_example = middleware::logger_example::LoggerExample::new();
     app.use_service(logger_example);
 
-    param_router.get("/test-next-wild/*", |ctx: Context| async {
-        ctx.build("<h1>test next wild</h1>".to_string()).ok()
+    app.scope("params", |router: &mut Router| {
+        router.get("/test-next-wild/*", |ctx: Context| async {
+            ctx.build("<h1>test next wild</h1>".to_string()).ok()
+        });
+
+        router.get("/*", |ctx: Context| async {
+            ctx.build(
+                "<h1>404 Not Found</h1>"
+                    .to_string()
+                    .with_status(StatusCode::NOT_FOUND),
+            )
+            .ok()
+        });
     });
 
-    param_router.get("/*", |ctx: Context| async {
-        ctx.build(
-            "<h1>404 Not Found</h1>"
-                .to_string()
-                .with_status(StatusCode::NOT_FOUND),
-        )
-        .ok()
-    });
-
-    app.use_router("/params/", param_router);
-    app.use_router("/forms/", form_router);
     app.use_static_to("/files/", "/assets/");
 
     app.listen(&addr, || {}).await;

--- a/src/app.rs
+++ b/src/app.rs
@@ -374,18 +374,4 @@ mod test {
             assert_eq!(actual_res_body.unwrap(), expected_res_body.unwrap());
         })
     }
-
-    #[test]
-    fn test_nested_router() {
-        task::block_on(async {
-            let mut app: App = App::new();
-
-            app.scope("admin", |router: &mut Router| {
-                router.get("list", |ctx: Context| async move {
-                    assert_eq!(ctx.uri().path(), "/admin//list");
-                    ctx.build("return here").ok()
-                });
-            });
-        })
-    }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -73,6 +73,13 @@ where
         self.router.delete(path, handler);
     }
 
+    pub fn scope(&mut self, name: &str, scoped_routes: impl Fn(&mut Router)) {
+        let mut new_router = Router::new();
+
+        scoped_routes(&mut new_router);
+        self.use_router(format!("/{}", name).as_ref(), new_router);
+    }
+
     /// Apply middleware in the provided route
     pub fn use_service_to(&mut self, path: &str, middleware: impl Middleware) {
         self.router.use_service_to(path, middleware);

--- a/src/context.rs
+++ b/src/context.rs
@@ -300,7 +300,7 @@ impl Context {
                 if !val.is_empty() {
                     parsed_form_map
                         .entry(key)
-                        .or_insert_with(|| vec![])
+                        .or_insert_with(Vec::new)
                         .push(val);
                 }
             });

--- a/src/router/req_deserializer.rs
+++ b/src/router/req_deserializer.rs
@@ -640,7 +640,7 @@ mod tests {
                 .push(2);
             expected_result
                 .entry("field2".to_string())
-                .or_insert_with(|| vec![])
+                .or_insert_with(Vec::new)
                 .push(3);
             assert_eq!(actual_result, expected_result);
         })

--- a/src/router/req_deserializer.rs
+++ b/src/router/req_deserializer.rs
@@ -475,7 +475,7 @@ mod tests {
                 .for_each(|(key, val)| {
                     parsed_form_map
                         .entry(key)
-                        .or_insert_with(|| vec![])
+                        .or_insert_with(Vec::new)
                         .push(val);
                 });
             // Wrap vec with cow pointer
@@ -512,7 +512,7 @@ mod tests {
                 .for_each(|(key, val)| {
                     parsed_form_map
                         .entry(key)
-                        .or_insert_with(|| vec![])
+                        .or_insert_with(Vec::new)
                         .push(val);
                 });
             // Wrap vec with cow pointer
@@ -546,7 +546,7 @@ mod tests {
                 .for_each(|(key, val)| {
                     parsed_form_map
                         .entry(key)
-                        .or_insert_with(|| vec![])
+                        .or_insert_with(Vec::new)
                         .push(val);
                 });
             // Wrap vec with cow pointer
@@ -580,7 +580,7 @@ mod tests {
                 .for_each(|(key, val)| {
                     parsed_form_map
                         .entry(key)
-                        .or_insert_with(|| vec![])
+                        .or_insert_with(Vec::new)
                         .push(val);
                 });
             // Wrap vec with cow pointer
@@ -617,7 +617,7 @@ mod tests {
                 .for_each(|(key, val)| {
                     parsed_form_map
                         .entry(key)
-                        .or_insert_with(|| vec![])
+                        .or_insert_with(Vec::new)
                         .push(val);
                 });
             // Wrap vec with cow pointer
@@ -632,11 +632,11 @@ mod tests {
 
             expected_result
                 .entry("field1".to_string())
-                .or_insert_with(|| vec![])
+                .or_insert_with(Vec::new)
                 .push(1);
             expected_result
                 .entry("field1".to_string())
-                .or_insert_with(|| vec![])
+                .or_insert_with(Vec::new)
                 .push(2);
             expected_result
                 .entry("field2".to_string())


### PR DESCRIPTION
Previously when we want to use nested route, we have to write:
```rust
// declare a nested router
let mut form_router = Router::new();

// declare nested route
form_router.get("/formtest", |ctx: Context| async move {
    ctx.build_file("./test.html").await.ok()
});

// register the nested router to the app
app.use_router("/forms/", form_router);
```

With the syntactic sugar:
```rust
app.scope("form", |router: &mut Router| {
    router.get("/formtest", |ctx: Context| async move {
        ctx.build_file("/.test.html").await.ok()
    });
});
```